### PR TITLE
Add logout button

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,15 @@
 <%= content_tag :h1, current_user.welcome %>
-<%= link_to "Sign out", session_path, method:"delete" %>
+
+<%
+# TODO: Fix this. I couldn't get an error resolved to get UJS working.
+# Module build failed (from ./node_modules/babel-loader/lib/index.js) (Check the console).
+
+# <%= link_to "Sign out", logout_path, method:"delete"
+%>
+
 <%= link_to "Home", root_path %>
+
+<%# Temporary workaround to bypass UJS issue from above. %>
+<%= form_with url: logout_path, method: :delete do %>
+  <%= submit_tag "Sign out" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,4 +18,5 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create, :index, :show]
   resources :sessions, only: [:new, :create, :destroy]
+  delete "/logout", to: "sessions#destroy", as: :logout
 end


### PR DESCRIPTION
Fixes: #28

I added a logout button to kill a session and redirect to the login page. For some reason some JS packages weren't loading properly, and I couldn't get them to work, so the method from the blog wasn't working to sign me out. It relied on `UJS` and `UJS` wasn't working.

This is the real way that isn't working:

```ruby
link_to "Sign out", logout_path, method:"delete"`=
```

This is the hacky fix:

```ruby
<%= form_with url: logout_path, method: :delete do %>
  <%= submit_tag "Sign out" %>
<% end %>
```

The form submission works because it is bypassing the `UJS` entirely, as it is submitting a `POST` request with a `delete` method attached straight through the browser (as opposed to an actual `DELETE` request that needs some JS involved) and has a respective route in `routes.rb` to map it to the `sessions#destroy` action. I still need to fix the `UJS` issue though.