### PR TITLE
Add issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+**Describe the Bug**
+
+
+**Steps to Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+
+**Expected Behavior**
+
+
+**Screenshots**
+
+
+**Additional Context**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a Bug
+    url: https://github.com/jaxonavena/Gymothy/issues/new?template=bug_report.md
+    about: Create a report to help us improve.
+  - name: Feature Request
+    url: https://github.com/jaxonavena/Gymothy/issues/new?template=feature_request.md
+    about: Suggest a new feature or improvement.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions you've considered.
+
+**Additional Context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,16 @@
+## Description
+<!-- Please include a summary of the change and what issue is fixed. -->
+
+## Related Issues
+<!-- Link to related issues if applicable. -->
+
+## Screenshots
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+
+## Checklist
+- [ ] Added specs
+- [ ] New and existing tests pass locally.


### PR DESCRIPTION
Fixes: https://github.com/jaxonavena/Gymothy/issues/16

Adding templates for both Github issues and pull requests. Now it should be easier to fill in necessary information to submit issues/PRs.