### PR TITLE
Integrate Stripe payment processing

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,2 @@
+STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key
+STRIPE_SECRET_KEY=sk_test_your_secret_key

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-debug.log*
 
 # Allows RSpec to persist some state between runs in order to support the `--only-failures` and `--next-failure` CLI options
 /spec/examples.txt
+
+# Ignore ENV
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ gem 'redis', '~> 4.0'
 gem 'bcrypt', '~> 3.1.7'
 # Add calendar functionality
 gem "simple_calendar"
+# Integrate Stripe payment processing
+gem 'stripe'
+# ENV
+gem "dotenv", require: "dotenv/load"
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
     date (3.3.4)
     debug_inspector (1.2.0)
     diff-lcs (1.5.1)
+    dotenv (2.8.1)
     drb (2.2.1)
     erubi (1.13.0)
     factory_bot (6.4.6)
@@ -289,6 +290,7 @@ GEM
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
     stringio (3.1.1)
+    stripe (8.6.0)
     strscan (3.1.0)
     thor (1.3.1)
     tilt (2.4.0)
@@ -342,6 +344,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   database_cleaner-active_record (~> 2.0)
+  dotenv
   factory_bot_rails (~> 6.0)
   faker (~> 2.0)
   importmap-rails
@@ -357,6 +360,7 @@ DEPENDENCIES
   simple_calendar
   spring
   sqlite3 (~> 1.4)
+  stripe
   turbo-rails
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -1,0 +1,31 @@
+class CheckoutsController < ApplicationController
+  def create
+    session = Stripe::Checkout::Session.create(
+      payment_method_types: ['card'],
+      line_items: [{
+        price_data: {
+          currency: 'usd',
+          product_data: {
+            name: 'Gym Membership',
+          },
+          unit_amount: 5000, # in cents
+        },
+        quantity: 1,
+      }],
+      mode: 'payment',
+      success_url: checkout_success_url,
+      cancel_url: checkout_cancel_url
+    )
+
+    redirect_to session.url, allow_other_host: true
+  rescue Stripe::StripeError => e
+    flash[:alert] = e.message
+    redirect_to root_path
+  end
+
+  def success
+  end
+
+  def cancel
+  end
+end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,27 @@
+class WebhooksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def stripe
+    event = nil
+    payload = request.body.read
+    sig_header = request.env['HTTP_STRIPE_SIGNATURE']
+    endpoint_secret = ENV['STRIPE_WEBHOOK_SECRET']
+
+    begin
+      event = Stripe::Webhook.construct_event(payload, sig_header, endpoint_secret)
+    rescue JSON::ParserError, Stripe::SignatureVerificationError => e
+      render json: { error: e.message }, status: 400
+      return
+    end
+
+    case event['type']
+    when 'checkout.session.completed'
+      # Fulfill the purchase, update the database
+      puts 'Payment successful!'
+    end
+
+    Rails.logger.info "Received event: #{event['type']}"
+
+    render json: { message: 'Success' }
+  end
+end

--- a/app/views/checkouts/checkout.html.erb
+++ b/app/views/checkouts/checkout.html.erb
@@ -1,0 +1,3 @@
+<%= form_with url: checkout_create_path, method: :post do %>
+  <%= submit_tag "Pay with Stripe" %>
+<% end %>

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,0 +1,6 @@
+Rails.configuration.stripe = {
+  publishable_key: ENV['STRIPE_PUBLISHABLE_KEY'],
+  secret_key: ENV['STRIPE_SECRET_KEY']
+}
+
+Stripe.api_key = Rails.configuration.stripe[:secret_key]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,13 @@ Rails.application.routes.draw do
     resources :comments
   end
 
+  # STRIPE
+  post 'checkout/create', to: 'checkouts#create'
+  get 'checkout/success', to: 'checkouts#success'
+  get 'checkout/cancel', to: 'checkouts#cancel'
+  # Stripe webhooks
+  post '/webhooks/stripe', to: 'webhooks#stripe'
+
   resources :businesses do
     get "analytics", on: :member
     resources :sites


### PR DESCRIPTION
Fixes: #56

I've integrated Stripe with Gymothy using Stripe's free Test API keys. I was shocked at how simple it was to get this running. I had to add a `.env` and `.env-example` file in order to include the API keys (`.env` is in `.gitignore`). I've also included the `dotenv` and `stripe` gem. I will need to add specs to test this behavior better, and research further into the API itself to see its full use cases, but I'm happy that it seems to be working. Well, working from the CLI. The next step will be to implement the UI.


![Screenshot 2025-01-21 at 1 48 02 PM](https://github.com/user-attachments/assets/59da2230-7a19-40b7-ac86-256d8e84b55c)

![Screenshot 2025-01-21 at 1 44 31 PM](https://github.com/user-attachments/assets/4c1a87f1-b860-44c2-a779-4d8bdc0b4600)
